### PR TITLE
Add tooltips into login form

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@angular/compiler": "^9.0.4",
     "@angular/core": "^9.0.4",
     "@angular/forms": "^9.0.4",
-    "@angular/material": "^9.1.0",
+    "@angular/material": "^9.2.4",
     "@angular/platform-browser": "^9.0.4",
     "@angular/platform-browser-dynamic": "^9.0.4",
     "@angular/router": "^9.0.4",

--- a/src/app/@theme/styles/styles.scss
+++ b/src/app/@theme/styles/styles.scss
@@ -38,3 +38,6 @@
   @include nb-overrides();
   @include material-overrides();
 };
+
+html, body { height: 100%; }
+body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }

--- a/src/app/@theme/styles/styles.scss
+++ b/src/app/@theme/styles/styles.scss
@@ -24,7 +24,6 @@
 
 // install the framework and custom global styles
 @include nb-install() {
-
   @include angular-material();
 
   // framework global styles
@@ -37,7 +36,13 @@
 
   @include nb-overrides();
   @include material-overrides();
-};
+}
 
-html, body { height: 100%; }
-body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
+html {
+  height: 100%;
+}
+body {
+  height: 100%;
+  margin: 0;
+  font-family: Roboto, 'Helvetica Neue', sans-serif;
+}

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -11,12 +11,16 @@
       <img src="../../assets/images/apache-fineract-logo.png">
     </div>
 
+    
     <nb-card class="login-form">
       <nb-card-header>Sign in to your account</nb-card-header>
       <nb-card-body>
         <form class="form-horizontal" [formGroup]="loginForm" (ngSubmit)="login()">
           <div class="form-group row">
-            <label for="tenant" class="label col-sm-3 form-control-label">Tenant</label>
+            <div class=" col-sm-3">
+              <label for="tenant" class="label form-control-label">Tenant</label>
+              <mat-icon class="help-icon" matTooltip="Provide a tenant name" matTooltipPosition="above">help</mat-icon>
+            </div>
             <div class="col-sm-9">
               <input nbInput fullWidth id="tenant" placeholder="Tenant" formControlName="tenant">
               <div *ngIf="tenant.invalid && (tenant.dirty || tenant.touched)">
@@ -25,7 +29,10 @@
             </div>
           </div>
           <div class="form-group row">
-            <label for="username" class="label col-sm-3 form-control-label">Username</label>
+            <div class=" col-sm-3">
+              <label for="username" class="label form-control-label">Username</label>
+              <mat-icon class="help-icon" matTooltip="The username is a unique identifier for the user" matTooltipPosition="above">help</mat-icon>
+            </div>
             <div class="col-sm-9">
               <input nbInput fullWidth id="username" placeholder="Username" formControlName="username">
               <div *ngIf="username.invalid && (username.dirty || username.touched)">
@@ -35,7 +42,10 @@
             </div>
           </div>
           <div class="form-group row">
-            <label for="password" class="label col-sm-3 form-control-label">Password</label>
+            <div class="col-sm-3">
+              <label for="password" class="label form-control-label">Password</label>
+              <mat-icon class="help-icon" matTooltip="The password which is associated with a unique username" matTooltipPosition="above">help</mat-icon>
+            </div>
             <div class="col-sm-9">
               <nb-form-field>
                 <input [type]="getInputType()" nbInput fullWidth id="password" placeholder="Password"

--- a/src/app/login/login.component.scss
+++ b/src/app/login/login.component.scss
@@ -44,8 +44,8 @@
 }
 
 .help-icon {
-  height: 0px;
-  width: 0px;
+  height: 5px;
+  width: 5px;
   font-size: 12px;
   color: rgb(23, 189, 230);
   padding-left: 5px;

--- a/src/app/login/login.component.scss
+++ b/src/app/login/login.component.scss
@@ -42,3 +42,12 @@
     width: 100%;
   }
 }
+
+.help-icon {
+  height: 0px;
+  width: 0px;
+  font-size: 12px;
+  color: rgb(23, 189, 230);
+  padding-left: 5px;
+  display: inline-block;
+}

--- a/src/app/login/login.module.ts
+++ b/src/app/login/login.module.ts
@@ -26,7 +26,7 @@ import { MatIconModule } from "@angular/material/icon";
     NbEvaIconsModule,
     CovalentLoadingModule,
     MatTooltipModule,
-    MatIconModule
+    MatIconModule,
   ],
   declarations: [LoginComponent],
 })

--- a/src/app/login/login.module.ts
+++ b/src/app/login/login.module.ts
@@ -7,6 +7,8 @@ import { LoginComponent } from './login.component';
 import { LoginRoutingModule } from './login-routing.module';
 import { NbEvaIconsModule } from '@nebular/eva-icons';
 import { NbButtonModule, NbCardModule, NbLayoutModule, NbInputModule, NbIconModule, NbFormFieldModule } from '@nebular/theme';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatIconModule } from "@angular/material/icon";
 
 @NgModule({
   imports: [
@@ -23,6 +25,8 @@ import { NbButtonModule, NbCardModule, NbLayoutModule, NbInputModule, NbIconModu
     ReactiveFormsModule,
     NbEvaIconsModule,
     CovalentLoadingModule,
+    MatTooltipModule,
+    MatIconModule
   ],
   declarations: [LoginComponent],
 })

--- a/src/app/login/login.module.ts
+++ b/src/app/login/login.module.ts
@@ -8,7 +8,7 @@ import { LoginRoutingModule } from './login-routing.module';
 import { NbEvaIconsModule } from '@nebular/eva-icons';
 import { NbButtonModule, NbCardModule, NbLayoutModule, NbInputModule, NbIconModule, NbFormFieldModule } from '@nebular/theme';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { MatIconModule } from "@angular/material/icon";
+import { MatIconModule } from '@angular/material/icon';
 
 @NgModule({
   imports: [

--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/png" href="./assets/images/mifos-logo.png">
   <link rel="icon" type="image/x-icon" href="./assets/images/mifos-logo.png">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
   <ngx-app>Loading...</ngx-app>


### PR DESCRIPTION

Have added tooltips into the login form using material font icons and material design tooltips.

**OS:** Ubuntu 20.04
**Node:** 14.13.1
**Angular CLI:** 9.1.7
**Material:** 9.2.4

Have added three tooltips that will be guiding users while typing user login credentials.  **Fixes #38**

#### Tested on

**Firefox:** 81.0

![Screenshot from 2020-12-12 02-06-19](https://user-images.githubusercontent.com/50411704/101957514-9c622180-3c27-11eb-8a98-5441128aed69.png)

