### PR TITLE
 Added custom styling to change password form

### DIFF
--- a/src/app/main/settings/change-password/change-password.component.html
+++ b/src/app/main/settings/change-password/change-password.component.html
@@ -1,11 +1,14 @@
-<nb-card>
+<nb-card class="password-card">
   <nb-card-header>Change Password</nb-card-header>
   <nb-card-body>
     <div *ngIf="forced">Please change your password in order to access digital bank</div>
     <form class="form-horizontal" [formGroup]="passwordForm" (ngSubmit)="changePassword()">
       <div class="form-group row">
-        <label for="newPassword" class="label col-sm-3 form-control-label">New Password</label>
-        <div class="col-sm-9">
+        <div class="col-sm-4">
+          <label for="newPassword" class="label form-control-label">New Password</label>
+          <mat-icon class="help-icon" matTooltip="The new password is used to login again with the current username" matTooltipPosition="above">help</mat-icon>
+        </div>
+        <div class="col-sm-8">
           <input type="password" nbInput id="newPassword" placeholder="New Password"
             formControlName="newPassword" autocomplete="change-user-password">
           <div *ngIf="newPassword.invalid && (newPassword.dirty || newPassword.touched)">
@@ -15,8 +18,11 @@
         </div>
       </div>
       <div class="form-group row">
-        <label for="confirmNewPassword" class="label col-sm-3 form-control-label">Confirm Password</label>
-        <div class="col-sm-9">
+        <div class="col-sm-4">
+          <label for="confirmNewPassword" class="label form-control-label">Confirm Password</label>
+          <mat-icon class="help-icon" matTooltip="The password should be matched with the above password" matTooltipPosition="above">help</mat-icon>
+        </div>
+        <div class="col-sm-8">
           <input type="password" nbInput id="confirmNewPassword" placeholder="Confirm Password"
             formControlName="confirmNewPassword" autocomplete="change-user-password">
           <div *ngIf="passwordForm.hasError('mismatch') && (confirmNewPassword.dirty || confirmNewPassword.touched)"
@@ -25,7 +31,7 @@
         </div>
       </div>
       <div class="form-group row">
-        <div class="offset-sm-3 col-sm-9">
+        <div class="offset-sm-4 col-sm-8">
           <button type="submit" nbButton [disabled]="!passwordForm.valid" status="warning">Change
             Password</button>
         </div>
@@ -33,3 +39,4 @@
     </form>
   </nb-card-body>
 </nb-card>
+

--- a/src/app/main/settings/change-password/change-password.component.scss
+++ b/src/app/main/settings/change-password/change-password.component.scss
@@ -1,0 +1,15 @@
+.password-card {
+  width: 30rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.help-icon {
+  height: 5px;
+  width: 5px;
+  font-size: 12px;
+  color: rgb(23, 189, 230);
+  padding-left: 5px;
+  display: inline-block;
+}
+

--- a/src/app/main/settings/settings.module.ts
+++ b/src/app/main/settings/settings.module.ts
@@ -20,7 +20,7 @@ import { MatIconModule } from '@angular/material/icon';
     NbInputModule,
     ReactiveFormsModule,
     MatIconModule,
-    MatTooltipModule
+    MatTooltipModule,
   ],
 })
 export class SettingsModule {}

--- a/src/app/main/settings/settings.module.ts
+++ b/src/app/main/settings/settings.module.ts
@@ -4,6 +4,8 @@ import { ChangePasswordComponent } from './change-password/change-password.compo
 import { SettingsRoutingModule } from './settings-routing.module';
 import { NbButtonModule, NbCardModule, NbLayoutModule, NbInputModule } from '@nebular/theme';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatIconModule } from '@angular/material/icon';
 
 @NgModule({
   declarations: [ChangePasswordComponent],
@@ -17,6 +19,9 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
     NbCardModule,
     NbInputModule,
     ReactiveFormsModule,
+    MatIconModule,
+    MatTooltipModule
   ],
 })
 export class SettingsModule {}
+


### PR DESCRIPTION
## Description

Added custom styling to change password form using bootstrap and css properties. Fixes #73 

### What's included?

- Added width and auto margin both from left and right so that form could be center-aligned
- Added tooltip to form-fields using material tooltip and font-icon

#### Tested On

**OS:** Ubuntu 20.04
**Node:** 14.13.1
**Angular CLI:** 9.1.7
**Material:** 9.2.4



![Screenshot from 2020-12-13 21-11-26](https://user-images.githubusercontent.com/50411704/102016987-ff6bc980-3d89-11eb-8cd3-be12d147276a.png)