### PR TITLE
Updated password error

### DIFF
--- a/src/app/main/settings/change-password/change-password.component.ts
+++ b/src/app/main/settings/change-password/change-password.component.ts
@@ -76,7 +76,7 @@ export class ChangePasswordComponent implements OnInit, OnDestroy {
   changePassword() {
     const newPassword: string = this.passwordForm.get('newPassword').value;
     if (this.password === newPassword) {
-      this.error = 'Password violates our password policy';
+      this.error = 'Password violates our password policy (New password same as old password)';
     } else {
       this.store.dispatch({
         type: CHANGE_PASSWORD,


### PR DESCRIPTION
## Description

A detailed error message describing exactly what the problem is (Password same as old password) makes it easier for the user to understand what went wrong. The earlier error may cause some confusion.

